### PR TITLE
Total on all statistics & improvements 

### DIFF
--- a/Controller/ProductStatisticController.php
+++ b/Controller/ProductStatisticController.php
@@ -91,8 +91,8 @@ class ProductStatisticController extends BaseAdminController
 
         foreach ($results as $index => $result) {
             for ($i = 1; $i <= 12; ++$i) {
-                $date = new \DateTime($productYear.'-'.$i);
-                if( !isset($result[$date->format('Y-n')]))
+                $date = new \DateTime($productYear . '-' . $i);
+                if (!isset($result[$date->format('Y-n')]))
                     $graph[$index][] = [$i - 1, 0];
                 else
                     $graph[$index][] = [$i - 1, floatval($result[$date->format('Y-n')][$type])];
@@ -111,6 +111,7 @@ class ProductStatisticController extends BaseAdminController
             $turnover
         );
 
+        // There are two graphs
         if (sizeof($graph) > 1) {
             $data->title = $this->getTranslator()->trans("Stats on %startYear and %endYear", array('%startYear' => $year, '%endYear' => $year2), Statistic::MESSAGE_DOMAIN);
             $turnover2->color = '#f39922';

--- a/Controller/StatisticController.php
+++ b/Controller/StatisticController.php
@@ -69,14 +69,23 @@ class StatisticController extends BaseAdminController
 
         $data = new \stdClass();
 
-        $data->title = $this->getTranslator()->trans("Stats between %startDay/%startMonth/%startYear and %endDay/%endMonth/%endYear", array(
-            '%startDay'=>$startDay,
-            '%startMonth' => $startMonth,
-            '%startYear' => $startYear,
-            '%endDay'=>$endDay,
-            '%endMonth'=>$endMonth,
-            '%endYear'=>$endYear
-        ), Statistic::MESSAGE_DOMAIN);
+        if ($startDay == $endDay && $startMonth == $endMonth && $startYear == $endYear) {
+            $data->title = $this->getTranslator()->trans("Stats between %startDay/%startMonth/%startYear", array(
+                '%startDay'=>$startDay,
+                '%startMonth' => $startMonth,
+                '%startYear' => $startYear,
+            ), Statistic::MESSAGE_DOMAIN);
+        }
+        else {
+            $data->title = $this->getTranslator()->trans("Stats between %startDay/%startMonth/%startYear and %endDay/%endMonth/%endYear", array(
+                '%startDay'=>$startDay,
+                '%startMonth' => $startMonth,
+                '%startYear' => $startYear,
+                '%endDay'=>$endDay,
+                '%endMonth'=>$endMonth,
+                '%endYear'=>$endYear
+            ), Statistic::MESSAGE_DOMAIN);
+        }
 
         $data->series = array(
             $average,
@@ -242,7 +251,6 @@ class StatisticController extends BaseAdminController
         $endYear = $this->getRequest()->query->get('endYear', date('Y'));
 
         $result[$startYear] = $this->getStatisticHandler()->getTurnoverYear($startYear);
-        $result[$endYear] = $this->getStatisticHandler()->getTurnoverYear($endYear);
 
         $turnoverStart = new \stdClass();
 
@@ -256,26 +264,31 @@ class StatisticController extends BaseAdminController
             'TTCWithoutShippping' => $this->getTranslator()->trans('tool.panel.general.turnover.TTCWithoutShippping', [], Statistic::MESSAGE_DOMAIN),
         );
 
-        $turnoverEnd = new \stdClass();
-
-        $turnoverEnd->color = '#F00';
-        $turnoverEnd->graph = $result[$endYear]['graph'];
-        $turnoverEnd->graphLabel = $result[$endYear]['month'];
-        $turnoverEnd->table = $result[$endYear]['table'];
-        $turnoverEnd->thead = array(
-            'month' => $this->getTranslator()->trans('tool.panel.general.turnover.month', [], Statistic::MESSAGE_DOMAIN),
-            'TTCWithShippping' => $this->getTranslator()->trans('tool.panel.general.turnover.TTCWithShippping', [], Statistic::MESSAGE_DOMAIN),
-            'TTCWithoutShippping' => $this->getTranslator()->trans('tool.panel.general.turnover.TTCWithoutShippping', [], Statistic::MESSAGE_DOMAIN),
-        );
-
-
         $data = new \stdClass();
-        $data->title = $this->getTranslator()->trans("Stats on %startYear and %endYear", array('%startYear' => $startYear, '%endYear' => $endYear),Statistic::MESSAGE_DOMAIN);
 
         $data->series = array(
             $turnoverStart,
-            $turnoverEnd
         );
+
+        if ($startYear != $endYear) {
+            $result[$endYear] = $this->getStatisticHandler()->getTurnoverYear($endYear);
+
+            $turnoverEnd = new \stdClass();
+
+            $turnoverEnd->color = '#F00';
+            $turnoverEnd->graph = $result[$endYear]['graph'];
+            $turnoverEnd->graphLabel = $result[$endYear]['month'];
+            $turnoverEnd->table = $result[$endYear]['table'];
+            $turnoverEnd->thead = array(
+                'month' => $this->getTranslator()->trans('tool.panel.general.turnover.month', [], Statistic::MESSAGE_DOMAIN),
+                'TTCWithShippping' => $this->getTranslator()->trans('tool.panel.general.turnover.TTCWithShippping', [], Statistic::MESSAGE_DOMAIN),
+                'TTCWithoutShippping' => $this->getTranslator()->trans('tool.panel.general.turnover.TTCWithoutShippping', [], Statistic::MESSAGE_DOMAIN),
+            );
+            array_push($data->series, $turnoverEnd);
+            $data->title = $this->getTranslator()->trans("Stats on %startYear and %endYear", array('%startYear' => $startYear, '%endYear' => $endYear), Statistic::MESSAGE_DOMAIN);
+        }
+        else
+            $data->title = $this->getTranslator()->trans("Stats on %startYear", array('%startYear' => $startYear), Statistic::MESSAGE_DOMAIN);
 
         return $this->jsonResponse(json_encode($data));
     }
@@ -316,14 +329,23 @@ class StatisticController extends BaseAdminController
 
         $data = new \stdClass();
 
-        $data->title = $this->getTranslator()->trans("Stats between %startDay/%startMonth/%startYear and %endDay/%endMonth/%endYear", array(
-            '%startDay'=>$startDay,
-            '%startMonth' => $startMonth,
-            '%startYear' => $startYear,
-            '%endDay'=>$endDay,
-            '%endMonth'=>$endMonth,
-            '%endYear'=>$endYear
-        ), Statistic::MESSAGE_DOMAIN);
+        if ($startDay == $endDay && $startMonth == $endMonth && $startYear == $endYear) {
+            $data->title = $this->getTranslator()->trans("Stats between %startDay/%startMonth/%startYear", array(
+                '%startDay'=>$startDay,
+                '%startMonth' => $startMonth,
+                '%startYear' => $startYear,
+            ), Statistic::MESSAGE_DOMAIN);
+        }
+        else {
+            $data->title = $this->getTranslator()->trans("Stats between %startDay/%startMonth/%startYear and %endDay/%endMonth/%endYear", array(
+                '%startDay'=>$startDay,
+                '%startMonth' => $startMonth,
+                '%startYear' => $startYear,
+                '%endDay'=>$endDay,
+                '%endMonth'=>$endMonth,
+                '%endYear'=>$endYear
+            ), Statistic::MESSAGE_DOMAIN);
+        }
 
         $data->series = array(
             $saleSeries,
@@ -386,14 +408,23 @@ class StatisticController extends BaseAdminController
 
         $data = new \stdClass();
 
-        $data->title = $this->getTranslator()->trans("Stats between %startDay/%startMonth/%startYear and %endDay/%endMonth/%endYear", array(
-            '%startDay'=>$startDay,
-            '%startMonth' => $startMonth,
-            '%startYear' => $startYear,
-            '%endDay'=>$endDay,
-            '%endMonth'=>$endMonth,
-            '%endYear'=>$endYear
-        ), Statistic::MESSAGE_DOMAIN);
+        if ($startDay == $endDay && $startMonth == $endMonth && $startYear == $endYear) {
+            $data->title = $this->getTranslator()->trans("Stats between %startDay/%startMonth/%startYear", array(
+                '%startDay'=>$startDay,
+                '%startMonth' => $startMonth,
+                '%startYear' => $startYear,
+            ), Statistic::MESSAGE_DOMAIN);
+        }
+        else {
+            $data->title = $this->getTranslator()->trans("Stats between %startDay/%startMonth/%startYear and %endDay/%endMonth/%endYear", array(
+                '%startDay'=>$startDay,
+                '%startMonth' => $startMonth,
+                '%startYear' => $startYear,
+                '%endDay'=>$endDay,
+                '%endMonth'=>$endMonth,
+                '%endYear'=>$endYear
+            ), Statistic::MESSAGE_DOMAIN);
+        }
 
         $data->series = array(
             $saleSeries,

--- a/I18n/en_US.php
+++ b/I18n/en_US.php
@@ -2,7 +2,9 @@
 
 return array(
     'Stats between %startDay/%startMonth/%startYear and %endDay/%endMonth/%endYear' => 'Statistics between %startDay/%startMonth/%startYear and %endDay/%endMonth/%endYear',
+    'Stats between %startDay/%startMonth/%startYear' => 'Statistics on %startDay/%startMonth/%startYear',
     'Stats on %startYear and %endYear' => 'Statistics for %startYear and %endYear',
+    'Stats on %startYear' => 'Statistics for %startYear',
     'tool.panel.annual.title' => 'Annual stats',
     'tool.panel.general.bestSales.name' => 'Name',
     'tool.panel.general.bestSales.reference' => 'Reference',

--- a/I18n/fr_FR.php
+++ b/I18n/fr_FR.php
@@ -2,7 +2,9 @@
 
 return array(
     'Stats between %startDay/%startMonth/%startYear and %endDay/%endMonth/%endYear' => 'Statistiques entre le %startDay/%startMonth/%startYear et le %endDay/%endMonth/%endYear',
+    'Stats between %startDay/%startMonth/%startYear' => 'Statistiques du %startDay/%startMonth/%startYear',
     'Stats on %startYear and %endYear' => 'Statistiques pour %startYear et %endYear',
+    'Stats on %startYear' => 'Statistiques pour %startYear',
     'tool.panel.annual.title' => 'Statistiques annuelles',
     'tool.panel.general.bestSales.name' => 'Nom',
     'tool.panel.general.bestSales.reference' => 'Référence',

--- a/templates/backOffice/default/assets/js/statistic-annual.js
+++ b/templates/backOffice/default/assets/js/statistic-annual.js
@@ -109,8 +109,9 @@
             let total = 0;
 
             jQplotData.series.forEach(entry => {
-                for (let i = 0; i < entry.graph.length; i++)
-                    total += entry.graph[i][1];
+                entry.graph.forEach(graph => {
+                    total += graph[1];
+                });
             });
 
             total = Math.round(total * 100) / 100;

--- a/templates/backOffice/default/assets/js/statistic-annual.js
+++ b/templates/backOffice/default/assets/js/statistic-annual.js
@@ -113,6 +113,8 @@
                     total += entry.graph[i][1];
             });
 
+            total = Math.round(total * 100) / 100;
+
             let s = document.getElementById('total-annual');
             s.innerHTML = total.toString();
         }

--- a/templates/backOffice/default/assets/js/statistic-annual.js
+++ b/templates/backOffice/default/assets/js/statistic-annual.js
@@ -105,6 +105,18 @@
             }
         }
 
+        function totalCalcul(jQplotData) {
+            let total = 0;
+
+            jQplotData.series.forEach(entry => {
+                for (let i = 0; i < entry.graph.length; i++)
+                    total += entry.graph[i][1];
+            });
+
+            let s = document.getElementById('total-annual');
+            s.innerHTML = total.toString();
+        }
+
         function retrieveJQPlotJson(startDate, endDate, callback) {
 
             $.getJSON(url, {
@@ -117,6 +129,7 @@
             })
                 .done(function (data) {
                     jQplotData = data;
+                    totalCalcul(jQplotData);
                     jsonSuccessLoad();
                     if (callback) {
                         callback();

--- a/templates/backOffice/default/assets/js/statistic-annual.js
+++ b/templates/backOffice/default/assets/js/statistic-annual.js
@@ -116,6 +116,7 @@
             total = Math.round(total * 100) / 100;
 
             let s = document.getElementById('total-annual');
+            $(s.parentElement).removeClass("hide");
             s.innerHTML = total.toString();
         }
 

--- a/templates/backOffice/default/assets/js/statistic-product.js
+++ b/templates/backOffice/default/assets/js/statistic-product.js
@@ -112,9 +112,10 @@
             function totalCalcul(jQplotData) {
                 let total = 0;
 
-                jQplotData.series.forEach(serie => {
-                    for (let i = 0; i < serie.graph.length; i++)
-                        total += serie.graph[i][1];
+                jQplotData.series.forEach(entry => {
+                    entry.graph.forEach(graph => {
+                        total += graph[1];
+                    });
                 });
 
                 total = Math.round(total * 100) / 100;

--- a/templates/backOffice/default/assets/js/statistic-product.js
+++ b/templates/backOffice/default/assets/js/statistic-product.js
@@ -117,6 +117,8 @@
                         total += serie.graph[i][1];
                 });
 
+                total = Math.round(total * 100) / 100;
+
                 let s = document.getElementById('total-prod');
                 s.innerHTML = total.toString();
             }

--- a/templates/backOffice/default/assets/js/statistic-product.js
+++ b/templates/backOffice/default/assets/js/statistic-product.js
@@ -120,6 +120,7 @@
                 total = Math.round(total * 100) / 100;
 
                 let s = document.getElementById('total-prod');
+                $(s.parentElement).removeClass("hide");
                 s.innerHTML = total.toString();
             }
 

--- a/templates/backOffice/default/assets/js/statistic-product.js
+++ b/templates/backOffice/default/assets/js/statistic-product.js
@@ -100,12 +100,25 @@
                 $.getJSON(url, {ref: productRef, year: productyear, year2: productyear2})
                     .done(function (data) {
                         jQplotData = data;
+                        totalCalcul(jQplotData);
                         jsonSuccessLoad();
                         if (callback) {
                             callback();
                         }
                     })
                     .fail(jsonFailLoad);
+            }
+
+            function totalCalcul(jQplotData) {
+                let total = 0;
+
+                jQplotData.series.forEach(serie => {
+                    for (let i = 0; i < serie.graph.length; i++)
+                        total += serie.graph[i][1];
+                });
+
+                let s = document.getElementById('total-prod');
+                s.innerHTML = total.toString();
             }
 
             function initJqplotData(json) {
@@ -199,6 +212,11 @@
         $("#product-select").change(function(e){
             setDataPlot(productUrl, id);
         });
+
+        // If there's an already loaded category, it loads all products.
+        let current_val = $('#category-select').val()
+        if (current_val)
+            $("#category-select").val(current_val).trigger("change");
 
         $('.js-btn-search-product').on('click', function(event){
             event.preventDefault();

--- a/templates/backOffice/default/assets/js/statistic.js
+++ b/templates/backOffice/default/assets/js/statistic.js
@@ -187,9 +187,10 @@
         function totalCalcul(jQplotData) {
             let total = 0;
 
-            jQplotData.series.forEach(serie => {
-                for (let i = 0; i < serie.graph.length; i++)
-                    total += serie.graph[i][1];
+            jQplotData.series.forEach(entry => {
+                entry.graph.forEach(graph => {
+                    total += graph[1];
+                });
             });
 
             total = Math.round(total * 100) / 100;

--- a/templates/backOffice/default/assets/js/statistic.js
+++ b/templates/backOffice/default/assets/js/statistic.js
@@ -192,12 +192,14 @@
                     total += serie.graph[i][1];
             });
 
+            total = Math.round(total * 100) / 100;
+
             let s = document.getElementById('total');
             s.innerHTML = total.toString();
         }
 
         function retrieveJQPlotJson(startDate, endDate, ghost, callback) {
-            if (typeof ghost === 'undefined'){
+            if (typeof ghost === 'undefined') {
                 ghost = 0;
             }
             $.getJSON(url, {

--- a/templates/backOffice/default/assets/js/statistic.js
+++ b/templates/backOffice/default/assets/js/statistic.js
@@ -195,6 +195,7 @@
             total = Math.round(total * 100) / 100;
 
             let s = document.getElementById('total');
+            $(s.parentElement).removeClass("hide");
             s.innerHTML = total.toString();
         }
 

--- a/templates/backOffice/default/assets/js/statistic.js
+++ b/templates/backOffice/default/assets/js/statistic.js
@@ -185,19 +185,18 @@
         }
 
         function totalCalcul(jQplotData) {
-            console.log(jQplotData);
             let total = 0;
 
-            for (let i = 0; i < jQplotData.series[0].graph.length; i++){
-                total += jQplotData.series[0].graph[i][1];
-            }
+            jQplotData.series.forEach(serie => {
+                for (let i = 0; i < serie.graph.length; i++)
+                    total += serie.graph[i][1];
+            });
 
             let s = document.getElementById('total');
-            s.innerHTML = "Total : " + total;
+            s.innerHTML = total.toString();
         }
 
         function retrieveJQPlotJson(startDate, endDate, ghost, callback) {
-
             if (typeof ghost === 'undefined'){
                 ghost = 0;
             }

--- a/templates/backOffice/default/hook/statistic-annual.html
+++ b/templates/backOffice/default/hook/statistic-annual.html
@@ -21,6 +21,6 @@
         <div id="jqplot-annual"></div>
     </div>
     <div class="total">
-        <h1 class="total-container hide">Total : <span id="total-annual"></span></h1>
+        <h1 class="hide">Total : <span id="total-annual"></span></h1>
     </div>
 </div>

--- a/templates/backOffice/default/hook/statistic-annual.html
+++ b/templates/backOffice/default/hook/statistic-annual.html
@@ -20,4 +20,7 @@
     <div class="jqplot-content">
         <div id="jqplot-annual"></div>
     </div>
+    <div class="total">
+        <h1>Total :<span id="total-annual"></span></h1>
+    </div>
 </div>

--- a/templates/backOffice/default/hook/statistic-annual.html
+++ b/templates/backOffice/default/hook/statistic-annual.html
@@ -21,6 +21,6 @@
         <div id="jqplot-annual"></div>
     </div>
     <div class="total">
-        <h1>Total :<span id="total-annual"></span></h1>
+        <h1 class="total-container hide">Total : <span id="total-annual"></span></h1>
     </div>
 </div>

--- a/templates/backOffice/default/hook/statistic-general.html
+++ b/templates/backOffice/default/hook/statistic-general.html
@@ -80,7 +80,7 @@
         <div id="jqplot-general"></div>
     </div>
     <div class="total">
-        <h1>Total :<span id="total"></span></h1>
+        <h1 class="total-container hide">Total : <span id="total"></span></h1>
     </div>
     <div class="table-content">
         <h2 id="table-title" class="text-center"></h2>

--- a/templates/backOffice/default/hook/statistic-general.html
+++ b/templates/backOffice/default/hook/statistic-general.html
@@ -80,7 +80,7 @@
         <div id="jqplot-general"></div>
     </div>
     <div class="total">
-        <h1 id="total">Total :</h1>
+        <h1>Total :<span id="total"></span></h1>
     </div>
     <div class="table-content">
         <h2 id="table-title" class="text-center"></h2>

--- a/templates/backOffice/default/hook/statistic-general.html
+++ b/templates/backOffice/default/hook/statistic-general.html
@@ -80,7 +80,7 @@
         <div id="jqplot-general"></div>
     </div>
     <div class="total">
-        <h1 class="total-container hide">Total : <span id="total"></span></h1>
+        <h1 class="hide">Total : <span id="total"></span></h1>
     </div>
     <div class="table-content">
         <h2 id="table-title" class="text-center"></h2>

--- a/templates/backOffice/default/hook/statistic-product.html
+++ b/templates/backOffice/default/hook/statistic-product.html
@@ -63,6 +63,10 @@
         </div>
     </div>
 
+    <div class="total">
+        <h1>Total :<span id="total-prod"></span></h1>
+    </div>
+
     <div class="modal fade js-modal-search-product" tabindex="-1" role="dialog" aria-hidden="true">
         <div class="modal-dialog">
             <div class="modal-content">

--- a/templates/backOffice/default/hook/statistic-product.html
+++ b/templates/backOffice/default/hook/statistic-product.html
@@ -64,7 +64,7 @@
     </div>
 
     <div class="total">
-        <h1 class="total-container hide">Total : <span id="total-prod"></span></h1>
+        <h1 class="hide">Total : <span id="total-prod"></span></h1>
     </div>
 
     <div class="modal fade js-modal-search-product" tabindex="-1" role="dialog" aria-hidden="true">

--- a/templates/backOffice/default/hook/statistic-product.html
+++ b/templates/backOffice/default/hook/statistic-product.html
@@ -64,7 +64,7 @@
     </div>
 
     <div class="total">
-        <h1>Total :<span id="total-prod"></span></h1>
+        <h1 class="total-container hide">Total : <span id="total-prod"></span></h1>
     </div>
 
     <div class="modal fade js-modal-search-product" tabindex="-1" role="dialog" aria-hidden="true">


### PR DESCRIPTION
### Type of change

* [x] Bug fix
* [ ] New feature
* [x] Improvement
* [ ] Breaking change
* [ ] This change is a documentation update

### Describe the changes:

- Added a total on annual statistics & product statistics
- Improved translations and graphs (only display one when the start and end time are the same)
- Fixed a bug where when reloading the page after selecting a category in product stats, the selected category will remain selected without loading the corresponding products
- Edited `totalCalcul()` to be more flexible on the number of graphs
- Improved some redundant parts of the code (but there are still many redundant code)
- Removed a forgotten`console.log()`
- Added few `Math.round()` in order to avoid weird total values